### PR TITLE
Add fclose to end of mapVBVD

### DIFF
--- a/libraries/FID-A/inputOutput/mapVBVD/mapVBVD.m
+++ b/libraries/FID-A/inputOutput/mapVBVD/mapVBVD.m
@@ -560,6 +560,8 @@ if NScans == 1
     twix_obj = twix_obj{1};
 end
 
+fclose(fid)
+
 end % of mapVBVD()
 
 


### PR DESCRIPTION
This change keeps MATLAB from crashing when running large datasets. Otherwise, every file remains open.